### PR TITLE
Add feedback page and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,4 +92,4 @@ The response will be streamed as an SSE `message` event with the result.
 
 ---
 
-MCPHub is open for public use. For questions or feedback, visit [mcph.io](https://mcph.io).
+MCPHub is open for public use. For questions or feedback, visit [mcph.io](https://mcph.io) or use the [feedback page](/feedback) in the app.

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { saveFeedback } from "@/services/firebaseService";
+import { v4 as uuidv4 } from "uuid";
+
+export async function POST(req: NextRequest) {
+  try {
+    const { message, email, userId } = await req.json();
+    if (!message || !message.trim()) {
+      return NextResponse.json({ error: "Message is required" }, { status: 400 });
+    }
+    const record = {
+      id: uuidv4(),
+      message,
+      email,
+      userId,
+      createdAt: new Date(),
+    };
+    const ok = await saveFeedback(record);
+    if (!ok) throw new Error("Failed to save");
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error("Error submitting feedback:", err);
+    return NextResponse.json({ error: "Failed to submit feedback" }, { status: 500 });
+  }
+}
+

--- a/app/feedback/metadata.ts
+++ b/app/feedback/metadata.ts
@@ -1,0 +1,7 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Feedback | MCPH",
+  description: "Send us your thoughts about MCPH",
+};
+

--- a/app/feedback/page.tsx
+++ b/app/feedback/page.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import React, { useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import Button from "@/components/ui/Button";
+
+export default function FeedbackPage() {
+  const { user } = useAuth();
+  const [message, setMessage] = useState("");
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!message.trim()) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message,
+          email: email || undefined,
+          userId: user?.uid,
+        }),
+      });
+      if (!res.ok) throw new Error("Failed to submit feedback");
+      setSuccess(true);
+      setMessage("");
+      setEmail("");
+    } catch (err) {
+      setError("Failed to submit feedback");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="max-w-xl mx-auto py-12">
+      <h1 className="text-2xl font-bold mb-4">Feedback</h1>
+      <p className="mb-6 text-gray-600">
+        We appreciate your thoughts and suggestions about MCPH.
+      </p>
+      {success && (
+        <div className="mb-4 text-green-600">Thank you for your feedback!</div>
+      )}
+      {error && <div className="mb-4 text-red-600">{error}</div>}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block mb-1 font-medium" htmlFor="message">
+            Message
+          </label>
+          <textarea
+            id="message"
+            className="w-full border rounded p-2"
+            rows={5}
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label className="block mb-1 font-medium" htmlFor="email">
+            Email (optional)
+          </label>
+          <input
+            id="email"
+            type="email"
+            className="w-full border rounded p-2"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </div>
+        <Button type="submit" disabled={loading || !message.trim()}
+          className="px-4 py-2 bg-blue-600 text-white rounded">
+          {loading ? "Sending..." : "Send Feedback"}
+        </Button>
+      </form>
+    </div>
+  );
+}
+

--- a/app/types/feedback.ts
+++ b/app/types/feedback.ts
@@ -1,0 +1,8 @@
+export interface FeedbackRecord {
+  id: string;
+  message: string;
+  email?: string;
+  userId?: string;
+  createdAt: Date;
+}
+

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -37,6 +37,12 @@ export default function Footer() {
             >
               Terms
             </Link>
+            <Link
+              href="/feedback"
+              className="text-gray-600 hover:text-primary-500 transition-colors"
+            >
+              Feedback
+            </Link>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- allow submitting feedback via `/feedback`
- store feedback in Firestore via new API route
- export feedback utilities in `firebaseService`
- link to feedback page from footer
- document feedback page in README

## Testing
- `npm run check` *(fails: cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_683ff6a120bc8325b8f5f3f642e80670